### PR TITLE
Add upcoming matches endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # estratego-flask
 Repositorio para servidor puente en Render.com usando Flask
+
+## Endpoint `/proximos_partidos`
+
+Permite obtener los próximos partidos (aún no iniciados) de la temporada donde compite un jugador.
+
+### Request
+
+```
+POST /proximos_partidos
+{
+  "jugador": "sr:competitor:123"
+}
+```
+
+### Response
+
+```
+{
+  "season_id": "sr:season:98765",
+  "partidos": [
+    {
+      "start_time": "2024-05-01T10:00:00Z",
+      "competitors": ["Jugador A", "Jugador B"],
+      "round": "1st_round"
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary
- add `obtener_proximos_partidos` to fetch not-started events for a season
- expose `season_id` from `obtener_puntos_defendidos`
- create `/proximos_partidos` route and document its usage

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689124e6dfc4832fbc228c8c9dfd8a8a