### PR TITLE
Parametrize year in player stats

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,11 +92,13 @@ def proximos_partidos():
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
-def obtener_estadisticas_jugador(player_id):
+def obtener_estadisticas_jugador(player_id, year=datetime.now().year):
     """Obtiene estadísticas recientes del jugador.
 
     Args:
         player_id (str): Identificador del jugador en Sportradar.
+        year (int, optional): Año del que se tomarán las estadísticas.
+            Por defecto se utiliza el año actual.
 
     Returns:
         dict: Información de ranking, victorias totales y rendimiento en
@@ -118,7 +120,7 @@ def obtener_estadisticas_jugador(player_id):
     clay_matches = 0
 
     for periodo in data.get("periods", []):
-        if periodo["year"] == 2025:
+        if periodo["year"] == year:
             for surface in periodo["surfaces"]:
                 stats = surface["statistics"]
                 wins = stats.get("matches_won", 0)


### PR DESCRIPTION
## Summary
- allow fetching player statistics for any year by adding optional `year` parameter with current year as default
- replace hardcoded year comparison with configurable `year` value

## Testing
- `python -m py_compile main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891acaca644832f82260f32a456d6c3