### PR TITLE
Use UTC-aware dates for defended points

### DIFF
--- a/main.py
+++ b/main.py
@@ -315,7 +315,7 @@ def obtener_puntos_defendidos(player_id):
     logging.info("🎾 Torneo actual detectado: %s", torneo_nombre)
 
      # 3. Buscar edición anterior del torneo
-    hoy = datetime.today()
+    hoy = datetime.now(timezone.utc)
     año_pasado = str(hoy.year - 1)
     
     # 🧩 Equivalencia directa entre seasons para torneos con sede rotativa


### PR DESCRIPTION
## Summary
- ensure defended point calculations use `datetime.now(timezone.utc)` instead of `datetime.today`

## Testing
- `pytest`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6891ae7bafe0832fb94acc9ea691a010