### PR TITLE
Use environment variable for Sportradar API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # estratego-flask
 Repositorio para servidor puente en Render.com usando Flask
 
+## Configuración de la API Key
+
+Define la variable de entorno `SPORTRADAR_API_KEY` con tu clave de Sportradar antes de ejecutar la aplicación:
+
+```bash
+export SPORTRADAR_API_KEY="tu_api_key"
+```
+
 ## Endpoint `/proximos_partidos`
 
 Permite obtener los próximos partidos (aún no iniciados) de la temporada donde compite un jugador.

--- a/main.py
+++ b/main.py
@@ -2,11 +2,12 @@ from flask import Flask, request, jsonify
 from datetime import datetime, timezone
 import requests
 import logging
+import os
 
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)
 
-API_KEY = "e4ufC11rvWZ7OXEKFhI1yKAiSsfH3Rv65viqBmJv"  # Reemplaza esto con tu API Key real de Sportradar
+API_KEY = os.environ.get("SPORTRADAR_API_KEY")  # API Key leída de la variable de entorno
 
 @app.route('/', methods=['POST'])
 def evaluar():


### PR DESCRIPTION
## Summary
- Replace hardcoded API key with value read from `SPORTRADAR_API_KEY` environment variable
- Document how to configure the `SPORTRADAR_API_KEY` environment variable in the README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6891b61188c0832fa017383f31d36bb8