### PR TITLE
Add docstring and type hints for upcoming matches helper

### DIFF
--- a/main.py
+++ b/main.py
@@ -393,7 +393,17 @@ def obtener_puntos_defendidos(player_id):
     return puntos, torneo_nombre, motivacion, ronda_str, log_debug, season_id
 
 
-def obtener_proximos_partidos(season_id):
+def obtener_proximos_partidos(season_id: str) -> list[dict]:
+    """Obtiene los próximos partidos para una temporada concreta.
+
+    Args:
+        season_id (str): Identificador de la temporada según Sportradar.
+
+    Returns:
+        list[dict]: Lista con la información de cada partido pendiente,
+        incluyendo ``start_time``, los ``competitors`` y la ``round``.
+    """
+
     url = f"https://api.sportradar.com/tennis/trial/v3/en/seasons/{season_id}/summaries.json"
     headers = {"accept": "application/json", "x-api-key": API_KEY}
     r = requests.get(url, headers=headers)


### PR DESCRIPTION
## Summary
- document `obtener_proximos_partidos` with clear purpose, arguments, and return value
- add type hints for `season_id` and returned list

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6891bb1056e8832fa32e4b23225e4c32