### PR TITLE
Maneja errores de red al obtener próximos partidos

### DIFF
--- a/main.py
+++ b/main.py
@@ -406,9 +406,11 @@ def obtener_proximos_partidos(season_id: str) -> list[dict]:
 
     url = f"https://api.sportradar.com/tennis/trial/v3/en/seasons/{season_id}/summaries.json"
     headers = {"accept": "application/json", "x-api-key": API_KEY}
-    r = requests.get(url, headers=headers)
-    if r.status_code != 200:
-        raise Exception("Error al obtener próximos partidos")
+    try:
+        r = requests.get(url, headers=headers, timeout=10)
+        r.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise Exception("Error al obtener próximos partidos") from e
 
     proximos = []
     for evento in r.json().get("summaries", []):


### PR DESCRIPTION
## Summary
- Agrega manejo de excepciones para la solicitud HTTP en `obtener_proximos_partidos`

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891bce63050832f83397623ef751745