### PR TITLE
Sort upcoming matches by start time

### DIFF
--- a/main.py
+++ b/main.py
@@ -428,6 +428,8 @@ def obtener_proximos_partidos(season_id: str) -> list[dict]:
             "round": round_name
         })
 
+    proximos.sort(key=lambda p: (p["start_time"] is None, p["start_time"] or ""))
+
     return proximos
 
 


### PR DESCRIPTION
## Summary
- sort upcoming match data by `start_time`
- handle `None` values safely during sorting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891bdfebd50832f8a3a6fb953cf0dfc