### PR TITLE
Improve Apps Script error handling for proximos_partidos_por_torneo

### DIFF
--- a/apps_script/proximos_partidos_por_torneo.gs
+++ b/apps_script/proximos_partidos_por_torneo.gs
@@ -1,0 +1,22 @@
+function fetchProximosPartidosPorTorneo(torneo) {
+  var url = 'https://example.com/proximos_partidos_por_torneo';
+  var payload = { torneo: torneo };
+  var options = {
+    method: 'post',
+    contentType: 'application/json',
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true,
+  };
+  var resp = UrlFetchApp.fetch(url, options);
+  var code = resp.getResponseCode();
+  if (code !== 200) {
+    console.error(resp.getContentText());
+    return null;
+  }
+  var contentType = resp.getHeaders()['Content-Type'] || '';
+  if (!contentType.includes('application/json')) {
+    console.error('Respuesta no JSON: ' + contentType);
+    return null;
+  }
+  return JSON.parse(resp.getContentText());
+}


### PR DESCRIPTION
## Summary
- add Apps Script example for `proximos_partidos_por_torneo` that enables `muteHttpExceptions`
- log non-200 responses and skip JSON parsing when not valid

## Testing
- `node -e "new Function(require('fs').readFileSync('apps_script/proximos_partidos_por_torneo.gs','utf8'))"`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6891e17879f4832fae599808eb7c212b