### PR TITLE
feat: add global exception handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,11 @@ import os
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)
 
+@app.errorhandler(Exception)
+def handle_exception(e):
+    """Captura excepciones no controladas y devuelve un JSON."""
+    return jsonify({"error": str(e)}), 500
+
 API_KEY = "e4ufC11rvWZ7OXEKFhI1yKAiSsfH3Rv65viqBmJv"  # Reemplaza esto con tu API Key real de Sportradar
 
 @app.route('/', methods=['POST'])


### PR DESCRIPTION
## Summary
- add global error handler that returns JSON for unhandled exceptions

## Testing
- `python -m py_compile main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e3674db4832fb184e3f2d5eba225