### PR TITLE
Allow Apps Script to send surface target for evaluations

### DIFF
--- a/apps_script/evaluarValueBetConEstadisticas.gs
+++ b/apps_script/evaluarValueBetConEstadisticas.gs
@@ -19,11 +19,17 @@ function evaluarValueBetConEstadisticas() {
     return;
   }
 
+  const superficieObjetivo = hojaFiltro.getRange(row, 16).getValue().toString().trim();
+
   const url = "https://estratego-api.onrender.com/";
   const payload = {
     "jugador": idJugador,
     "rival": idRival
   };
+
+  if (superficieObjetivo) {
+    payload.superficie_objetivo = superficieObjetivo;
+  }
 
   const options = {
     method: "post",

--- a/main.py
+++ b/main.py
@@ -58,10 +58,9 @@ def evaluar():
         puntos_defendidos, torneo_actual, motivacion_por_puntos, ronda_maxima, log_debug, _ = obtener_puntos_defendidos(jugador_id)
         cambio_superficie_bool = False
         if superficie_objetivo:
-            if superficie_objetivo:
-    cambio_superficie_bool = viene_de_cambio_de_superficie(
-        jugador_id, superficie_objetivo
-    )
+            cambio_superficie_bool = viene_de_cambio_de_superficie(
+                jugador_id, superficie_objetivo
+            )
 
 
         return jsonify({


### PR DESCRIPTION
## Summary
- read target surface from sheet in `evaluarValueBetConEstadisticas.gs` and include it in API payload
- ensure Flask endpoint checks for surface change when `superficie_objetivo` is present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68920dc65168832f86f0bf62e3e2e424