### PR TITLE
Allow partial tournament name matching

### DIFF
--- a/tests/test_buscar_season_id.py
+++ b/tests/test_buscar_season_id.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import main
+
+
+class MockResp:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+def test_buscar_season_id_por_nombre_partial(monkeypatch):
+    sample = {
+        "seasons": [
+            {"id": "sr:season:1", "name": "ATP Toronto, Canada Men Singles 2025", "year": 2025}
+        ]
+    }
+
+    def mock_get(url, headers, timeout):
+        return MockResp(sample)
+
+    monkeypatch.setattr(main.requests, "get", mock_get)
+
+    assert main.buscar_season_id_por_nombre("toronto 2025") == "sr:season:1"
+
+
+def test_buscar_season_id_por_nombre_not_found(monkeypatch):
+    sample = {
+        "seasons": [
+            {"id": "sr:season:1", "name": "ATP Toronto, Canada Men Singles 2025", "year": 2025}
+        ]
+    }
+
+    def mock_get(url, headers, timeout):
+        return MockResp(sample)
+
+    monkeypatch.setattr(main.requests, "get", mock_get)
+
+    assert main.buscar_season_id_por_nombre("madrid") is None


### PR DESCRIPTION
## Summary
- make `buscar_season_id_por_nombre` more robust by matching tokens in the tournament name, allowing partial or loosely formatted inputs
- add tests for season lookup helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893018ba1ac832f82bee6aefd7ee013