### PR TITLE
Handle non-string surfaces in surface color helper

### DIFF
--- a/apps_script/evaluarValueBetConEstadisticas.gs
+++ b/apps_script/evaluarValueBetConEstadisticas.gs
@@ -140,7 +140,7 @@ function colorPorSuperficie(superficie) {
     clay: "#D35400",
     grass: "#27AE60"
   };
-  if (!superficie) {
+  if (typeof superficie !== "string" || superficie.trim() === "") {
     return "#BDC3C7"; // color neutro para desconocidos
   }
   const clave = superficie.toLowerCase();


### PR DESCRIPTION
## Summary
- Prevent runtime error when surface data isn't a string in `colorPorSuperficie`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689314695914832f8ae3b46c95d947c5