### PR TITLE
Add surface preference visual cues in spreadsheet

### DIFF
--- a/apps_script/evaluarValueBetConEstadisticas.gs
+++ b/apps_script/evaluarValueBetConEstadisticas.gs
@@ -49,6 +49,10 @@ function evaluarValueBetConEstadisticas() {
   const result = JSON.parse(response.getContentText());
   Logger.log(result.ultimos_5_detalle);
 
+  hojaFiltro.getRange(row, 17)
+            .setBackground(colorPorSuperficie(result.superficie_favorita));
+  hojaFiltro.getRange(row, 18).setValue(result.porcentaje_superficie_favorita);
+
 
   if (result.error) {
     hojaFiltro.getRange(row, 3).setValue("❌ " + result.error);


### PR DESCRIPTION
## Summary
- Highlight favorite surface color and percentage in Value Bet sheet

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68933dbb37cc832f84b308bf19d18e25