### PR TITLE
Handle new court surfaces in color mapping

### DIFF
--- a/apps_script/evaluarValueBetConEstadisticas.gs
+++ b/apps_script/evaluarValueBetConEstadisticas.gs
@@ -140,8 +140,9 @@ function buscarPlayerInfo(nombre, hoja) {
 
 function colorPorSuperficie(superficie) {
   const colores = {
-    hard: "#4A90E2",
-    clay: "#D35400",
+    hardcourt_outdoor: "#4A90E2",
+    hardcourt_indoor: "#5DADE2",
+    red_clay: "#D35400",
     grass: "#27AE60"
   };
   if (typeof superficie !== "string" || superficie.trim() === "") {


### PR DESCRIPTION
## Summary
- expand surface color mapping to include hardcourt_outdoor, hardcourt_indoor, red_clay, and grass
- normalize surface strings and default to neutral color if unknown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68933f57f9ac832f8ef19d06392fad66