### PR TITLE
Buscar season más reciente sin año

### DIFF
--- a/main.py
+++ b/main.py
@@ -527,6 +527,8 @@ def buscar_season_id_por_nombre(torneo_full: str) -> str | None:
         else:
             tokens_without_year.append(tok)
 
+    matches = []
+
     for season in r.json().get("seasons", []):
         season_name = season.get("name", "")
         season_cf = season_name.casefold()
@@ -536,9 +538,16 @@ def buscar_season_id_por_nombre(torneo_full: str) -> str | None:
             continue
 
         if all(tok in season_cf for tok in tokens_without_year):
-            return season.get("id")
+            matches.append(season)
 
-    return None
+    if not matches:
+        return None
+
+    if year:
+        return matches[0].get("id")
+
+    latest = max(matches, key=lambda s: s.get("year", 0))
+    return latest.get("id")
 
 
 def obtener_proximos_partidos(season_id: str) -> list[dict]:

--- a/tests/test_buscar_season_id.py
+++ b/tests/test_buscar_season_id.py
@@ -16,11 +16,11 @@ class MockResp:
     def raise_for_status(self):
         pass
 
-
-def test_buscar_season_id_por_nombre_partial(monkeypatch):
+def test_buscar_season_id_por_nombre_con_ano(monkeypatch):
     sample = {
         "seasons": [
-            {"id": "sr:season:1", "name": "ATP Toronto, Canada Men Singles 2025", "year": 2025}
+            {"id": "sr:season:1", "name": "ATP Toronto, Canada Men Singles 2024", "year": 2024},
+            {"id": "sr:season:2", "name": "ATP Toronto, Canada Men Singles 2025", "year": 2025},
         ]
     }
 
@@ -29,7 +29,24 @@ def test_buscar_season_id_por_nombre_partial(monkeypatch):
 
     monkeypatch.setattr(main.requests, "get", mock_get)
 
-    assert main.buscar_season_id_por_nombre("toronto 2025") == "sr:season:1"
+    assert main.buscar_season_id_por_nombre("toronto 2024") == "sr:season:1"
+
+
+def test_buscar_season_id_por_nombre_mas_reciente(monkeypatch):
+    sample = {
+        "seasons": [
+            {"id": "sr:season:1", "name": "ATP Toronto, Canada Men Singles 2023", "year": 2023},
+            {"id": "sr:season:2", "name": "ATP Toronto, Canada Men Singles 2024", "year": 2024},
+            {"id": "sr:season:3", "name": "ATP Toronto, Canada Men Singles 2025", "year": 2025},
+        ]
+    }
+
+    def mock_get(url, headers, timeout):
+        return MockResp(sample)
+
+    monkeypatch.setattr(main.requests, "get", mock_get)
+
+    assert main.buscar_season_id_por_nombre("toronto") == "sr:season:3"
 
 
 def test_buscar_season_id_por_nombre_not_found(monkeypatch):


### PR DESCRIPTION
## Summary
- Acumula todas las temporadas coincidentes y selecciona la más reciente cuando no se especifica año
- Añade pruebas que cubren la selección de la temporada más reciente y la búsqueda con año

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689486c45a2c832f8b0d982ca28d23a9