### PR TITLE
Añade año actual a torneos sin año en Apps Script

### DIFF
--- a/apps_script/proximos_partidos_por_torneo.gs
+++ b/apps_script/proximos_partidos_por_torneo.gs
@@ -1,7 +1,13 @@
 function insertarProximosPartidosDesdeCelda() {
   const ss     = SpreadsheetApp.getActiveSpreadsheet();
   const sheet  = ss.getActiveSheet();
-  const torneo = sheet.getActiveCell().getValue().trim();
+  let torneo   = sheet.getActiveCell().getValue().trim();
+
+  if (!/\d{4}/.test(torneo)) {
+    const year = new Date().getFullYear();
+    torneo = `${torneo} ${year}`;
+    SpreadsheetApp.getUi().alert(`Año ${year} añadido automáticamente.`);
+  }
 
   const url = 'https://estratego-api.onrender.com/proximos_partidos_por_torneo';
   const params = {


### PR DESCRIPTION
## Summary
- Add year detection for active cell in `insertarProximosPartidosDesdeCelda`.
- Append current year and alert the user when missing before requesting matches.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ddb6f6b0832fa61346bae34904fd