### PR TITLE
Refactor profile retrieval for player stats

### DIFF
--- a/tests/test_buscar_season_id.py
+++ b/tests/test_buscar_season_id.py
@@ -9,6 +9,8 @@ import main
 class MockResp:
     def __init__(self, data):
         self._data = data
+        self.status_code = 200
+        self.headers = {}
 
     def json(self):
         return self._data
@@ -24,7 +26,7 @@ def test_buscar_season_id_por_nombre_con_ano(monkeypatch):
         ]
     }
 
-    def mock_get(url, headers, timeout):
+    def mock_get(url, headers=None, timeout=None):
         return MockResp(sample)
 
     monkeypatch.setattr(main.requests, "get", mock_get)
@@ -41,7 +43,7 @@ def test_buscar_season_id_por_nombre_mas_reciente(monkeypatch):
         ]
     }
 
-    def mock_get(url, headers, timeout):
+    def mock_get(url, headers=None, timeout=None):
         return MockResp(sample)
 
     monkeypatch.setattr(main.requests, "get", mock_get)
@@ -56,7 +58,7 @@ def test_buscar_season_id_por_nombre_not_found(monkeypatch):
         ]
     }
 
-    def mock_get(url, headers, timeout):
+    def mock_get(url, headers=None, timeout=None):
         return MockResp(sample)
 
     monkeypatch.setattr(main.requests, "get", mock_get)

--- a/tests/test_cambio_superficie.py
+++ b/tests/test_cambio_superficie.py
@@ -10,9 +10,13 @@ class MockResp:
     def __init__(self, data):
         self.status_code = 200
         self._data = data
+        self.headers = {}
 
     def json(self):
         return self._data
+
+    def raise_for_status(self):
+        pass
 
 
 def test_viene_de_cambio_de_superficie_true(monkeypatch):
@@ -26,7 +30,7 @@ def test_viene_de_cambio_de_superficie_true(monkeypatch):
         ]
     }
 
-    def mock_get(url, headers):
+    def mock_get(url, headers=None, timeout=None):
         return MockResp(sample)
 
     monkeypatch.setattr(main.requests, "get", mock_get)
@@ -45,7 +49,7 @@ def test_viene_de_cambio_de_superficie_false(monkeypatch):
         ]
     }
 
-    def mock_get(url, headers):
+    def mock_get(url, headers=None, timeout=None):
         return MockResp(sample)
 
     monkeypatch.setattr(main.requests, "get", mock_get)

--- a/tests/test_evaluar_superficie_favorita.py
+++ b/tests/test_evaluar_superficie_favorita.py
@@ -10,20 +10,24 @@ class MockResp:
     def __init__(self, data):
         self.status_code = 200
         self._data = data
+        self.headers = {}
 
     def json(self):
         return self._data
 
+    def raise_for_status(self):
+        pass
+
 
 def test_evaluar_includes_superficie_favorita(monkeypatch):
-    def mock_get(url, headers=None):
+    def mock_get(url, timeout=None, headers=None):
         return MockResp({})
 
     monkeypatch.setattr(main.requests, "get", mock_get)
     monkeypatch.setattr(
         main,
         "obtener_estadisticas_jugador",
-        lambda pid: {
+        lambda pid, year=None, perfil=None: {
             "ranking": 1,
             "victorias_totales": 0,
             "partidos_totales": 0,
@@ -36,7 +40,7 @@ def test_evaluar_includes_superficie_favorita(monkeypatch):
     monkeypatch.setattr(
         main,
         "calcular_superficie_favorita",
-        lambda pid: ("clay", 70.0),
+        lambda pid, perfil=None: ("clay", 70.0),
     )
     monkeypatch.setattr(
         main,

--- a/tests/test_superficie_favorita.py
+++ b/tests/test_superficie_favorita.py
@@ -10,9 +10,13 @@ class MockResp:
     def __init__(self, data):
         self.status_code = 200
         self._data = data
+        self.headers = {}
 
     def json(self):
         return self._data
+
+    def raise_for_status(self):
+        pass
 
 
 def test_calcular_superficie_favorita(monkeypatch):
@@ -28,7 +32,7 @@ def test_calcular_superficie_favorita(monkeypatch):
         ]
     }
 
-    def mock_get(url):
+    def mock_get(url, timeout=None, headers=None):
         return MockResp(sample)
 
     monkeypatch.setattr(main.requests, "get", mock_get)
@@ -50,7 +54,7 @@ def test_calcular_superficie_favorita_zero(monkeypatch):
         ]
     }
 
-    def mock_get(url):
+    def mock_get(url, timeout=None, headers=None):
         return MockResp(sample)
 
     monkeypatch.setattr(main.requests, "get", mock_get)


### PR DESCRIPTION
## Summary
- add helper `get_player_profile` to fetch a player's profile once
- let `obtener_estadisticas_jugador` and `calcular_superficie_favorita` reuse a provided profile
- fetch profile once in `evaluar` and share it between functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ac104214832fa0a37afb70ec3394