### PR TITLE
refactor: organize imports in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
-from flask import Flask, request, jsonify, Response
+
 from datetime import datetime, timezone
-import os, re, json, logging, urllib.parse, requests
+import json
+import logging
+import os
+import re
+import urllib.parse
 from typing import Any
 
+from flask import Flask, Response, jsonify, request
+import requests
+
 # Servicios/Utilidades
-from services import supabase_fs as FS
 from services import sportradar_now as SR
-from utils.scoring import logistic, clamp, WEIGHTS, ADJUSTS
+from services import supabase_fs as FS
+from utils.scoring import ADJUSTS, WEIGHTS, clamp, logistic
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- split combined imports into one per module
- group imports by standard library, third-party, and local modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ad7a6ca8832f985e9d8005d2f224